### PR TITLE
Cake electrs fork updates

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -185,7 +185,12 @@ impl Index {
         sp_skip_height: Option<usize>,
     ) -> Result<bool> {
         let mut start = 0;
-        let initial_height = sp_begin_height.unwrap_or(70_000);
+        // Taproot activates around 709,000 and Silent Payments start appearing > 800,000
+        // These numbers are specific to mainnet, for regtest/testnet/signet, sp_begin_height
+        // should be specified
+        //
+        // TODO: make 800_000 a constant whose value network specific
+        let initial_height = sp_begin_height.unwrap_or(800_000);
 
         if let Some(sp_skip_height) = sp_skip_height {
             start = sp_skip_height;
@@ -223,10 +228,6 @@ impl Index {
             } else {
                 start = initial_height;
             }
-        }
-
-        if start == initial_height {
-            panic!("start height is the same as initial height");
         }
 
         let new_header = self


### PR DESCRIPTION
Been doing some testing and review, here are some bug fixes/improvements. Longterm, my goal is to get the electrs fork ready for a PR to the upstream electrs rep, but no reason not to update little things as I go along.

The main change here is now clients doing long rescans will download less data since a txid and tweak will only be included in the response if it has at least one unspent output.

Also let some thoughts in the comments (mostly for myself). cc @rafael-xmr 